### PR TITLE
Fix code style issues

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -13,7 +13,12 @@ MainWindow::MainWindow(QWidget *parent) :
     ui->setupUi(this);
     QValidator *validator = new QIntValidator();
     ui->baudRateLE->setValidator(validator);
+    ui->baudRateLE->setText("115200");
     locateSerialPort();
+
+    connect(ui->connectPB, &QPushButton::clicked, this, &MainWindow::click);
+    connect(ui->disconnectPB, &QPushButton::clicked, this, &MainWindow::click);
+    connect(ui->sendPB,  &QPushButton::clicked, this, &MainWindow::click);
 }
 
 MainWindow::~MainWindow()
@@ -55,34 +60,25 @@ void MainWindow::locateSerialPort()
     }
 
 }
-/**
- * @brief MainWindow::on_connectPB_clicked
- * Start the communication between the serial device
- * and the computer
- */
-void MainWindow::on_connectPB_clicked()
-{
-    QString port = ui->serialPortCB->currentText();
-    uint baud = ui->baudRateLE->text().toUInt();
-    ser = new SerialLayer(port, baud);
-    qDebug() << "Connected!";
 
-}
-/**
- * @brief MainWindow::on_sendPB_clicked
- * Send command to serial port
- */
-void MainWindow::on_sendPB_clicked()
+void MainWindow::click()
 {
-    QByteArray comm = ui->commandLE->text().toLocal8Bit();
-    ser->pushCommand(comm);
-    qDebug() << "Command send it!";
-}
-/**
- * @brief MainWindow::on_disconnectPB_clicked
- * Close Serial Port
- */
-void MainWindow::on_disconnectPB_clicked()
-{
-    //Close serial port
+     QPushButton *btn = qobject_cast<QPushButton*>(sender());
+    if(btn == ui->connectPB ){
+
+        QString port = ui->serialPortCB->currentText();
+        uint baud = ui->baudRateLE->text().toUInt();
+        ser = new SerialLayer(port, baud);
+        qDebug() << "Connected!";
+
+    } else if(btn == ui->disconnectPB){
+        //Disconnect
+
+    } else if(btn == ui->sendPB){
+
+        QByteArray comm = ui->commandLE->text().toLocal8Bit();
+        ser->pushCommand(comm);
+        qDebug() << "Command send it!";
+
+    }
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -18,16 +18,10 @@ public:
 
     void checkCommand();
 
-private slots:
-    void on_connectPB_clicked();
-
-    void on_sendPB_clicked();
-
-    void on_disconnectPB_clicked();
-
 private:
     SerialLayer *ser;
     Ui::MainWindow *ui;
     void locateSerialPort();
     QStringList serialPortList;
+    void click();
 };


### PR DESCRIPTION
Some methods was created automatically, but they break
the code style.
Change to use local signals/slots, in one method.

Signed-off-by: Lays Rodrigues <laysrodriguessilva@gmail.com>