### PR TITLE
Add Serial Layer Logging on push command

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -34,6 +34,14 @@ void MainWindow::checkCommand()
         ui->logTE->appendPlainText(QString("Recv: %1").arg(QString(ser->popCommand())));
 }
 
+void MainWindow::checkPushedCommands(QString msg)
+{
+    QRegExp _newLine(QChar('\n'));
+    QRegExp _return(QChar('\r'));
+    msg.replace(_newLine, QString("\\n"));
+    msg.replace(_return, QString("\\r"));
+    ui->logTE->appendPlainText(msg);
+}
 /**
  * @brief MainWindow::locateSerialPort
  * Locate all active serial ports on the computer and add to the list
@@ -77,6 +85,7 @@ void MainWindow::click()
         _timer->setInterval(1000);
         _timer->start();
         connect(_timer,&QTimer::timeout, this, &MainWindow::checkCommand);
+        connect(ser, &SerialLayer::pushedCommand, this, &MainWindow::checkPushedCommands);
         ui->logTE->clear();
         ui->logTE->appendPlainText(QString(tr("Connected to %1").arg(port)));
 
@@ -91,7 +100,6 @@ void MainWindow::click()
         QByteArray comm = ui->commandLE->text().toUpper().toLocal8Bit() + "\n";
         ser->pushCommand(comm);
         ui->commandLE->clear();
-        ui->logTE->appendPlainText(QString(tr("Send: %1").arg(QString(comm))));
 
     }
 }

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -17,6 +17,7 @@ public:
 
 public slots:
     void checkCommand();
+    void checkPushedCommands(QString);
 
 private:
     SerialLayer *ser;

--- a/src/seriallayer.cpp
+++ b/src/seriallayer.cpp
@@ -54,6 +54,7 @@ void SerialLayer::readData()
 void SerialLayer::pushCommand(QByteArray comm)
 {
     serial->write(comm);
+    emit(pushedCommand(QString("SerialLayer<<%1").arg(QString(comm))));
 }
 
 void SerialLayer::add(QByteArray comm)
@@ -66,6 +67,7 @@ void SerialLayer::push()
     foreach(const auto& comm, _sByteCommands)
     {
         serial->write(comm);
+        emit(pushedCommand(QString("SerialLayer<<%1").arg(QString(comm))));
     }
     _sByteCommands.clear();
 }

--- a/src/seriallayer.h
+++ b/src/seriallayer.h
@@ -18,6 +18,8 @@ private:
     QByteArray _rawData;
     QVector<QByteArray> _rByteCommands;
     QVector<QByteArray> _sByteCommands;
+signals:
+    void pushedCommand(QString);
 public:
     SerialLayer(QString port, uint baud, QWidget *parent = 0);
     ~SerialLayer();


### PR DESCRIPTION
Serial Layer has  a new signal "pushedCommand(QString) that will be emited when a command is pushed.
MainWindow will log this even and replace \r and \n with  ␍ and ␤ to keep the command on one line in the log.