### PR TITLE
seriallayer: solve bug when calling popcommand without command to pop

### DIFF
--- a/src/seriallayer.cpp
+++ b/src/seriallayer.cpp
@@ -89,7 +89,7 @@ void SerialLayer::push()
 
 QByteArray SerialLayer::popCommand()
 {
-    return _rByteCommands.takeFirst();
+    return commandAvailable() ? _rByteCommands.takeFirst() : QByteArray();
 }
 
 bool SerialLayer::commandAvailable()


### PR DESCRIPTION
Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>